### PR TITLE
fix(widgets): All columns sortable, hidden dropdown

### DIFF
--- a/src/column.html
+++ b/src/column.html
@@ -1,5 +1,5 @@
 <template>
-  <div class="column ${'col-xs-' + column.width}">
+  <div class="column ${'col-xs-' + column.width}" ref="el">
   	${column.name}
     <div class="widget-row row" repeat.for="widget of column.widgets">
       <compose view-model="./widget" model.bind="widget"></compose>

--- a/src/column.js
+++ b/src/column.js
@@ -15,14 +15,23 @@ export class Column {
 
   addWidget () {
   	this.column.widgets.push(new Models.Widget());
+    console.log(this.column.widgets);
   }
 
   attached() {
-    var list = document.querySelectorAll(".column")[0];
-    console.log(list);
-    sortable.create(list, {
+    sortable.create(this.el, {
       animation: 150,
-      draggable: '.widget-row'
+      draggable: '.widget-row',
+      onEnd: (evt) => {
+          this.column.widgets.move(evt.oldIndex, evt.newIndex);
+          console.log(this.column.widgets);
+      }
     });
   }
 }
+
+Array.prototype.move = function (old_index, new_index) {
+    var element = this[old_index];
+    this.splice(old_index, 1);
+    this.splice(new_index, 0, element);
+};

--- a/src/layout.html
+++ b/src/layout.html
@@ -6,7 +6,7 @@
 		<h2>${heading}</h2>
     <div class="container-fluid">
       <form class="col-sm-2">
-        <div class="form-group" show.bind="showing">
+        <div class="form-group">
           <label>Choose # of Columns</label>
           <select class="form-control" selected-item.two-way="selectedColumns">
             <option repeat.for="option of availableColumns" value.bind="option" model.bind="option">${option.name}</option>

--- a/src/layout.js
+++ b/src/layout.js
@@ -25,6 +25,7 @@ export class Welcome{
     ];
     this.selectedColumns = this.availableColumns[0];
     this.showing = false;
+
     var self = this;
     this.showModal = function () {
       self.showing = !self.showing;


### PR DESCRIPTION
fix(widgets): All columns sortable, hidden dropdown

This fixes the hidden dropdown by removing the show.binding, as well as
incorporates a fix so that all columns are sortable. Additionally the
underlying list is now sorted as well
